### PR TITLE
Extended teleport command

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2,17 +2,17 @@
 
 /*
  *
- *  _                       _           _ __  __ _             
- * (_)                     (_)         | |  \/  (_)            
- *  _ _ __ ___   __ _  __ _ _  ___ __ _| | \  / |_ _ __   ___  
- * | | '_ ` _ \ / _` |/ _` | |/ __/ _` | | |\/| | | '_ \ / _ \ 
- * | | | | | | | (_| | (_| | | (_| (_| | | |  | | | | | |  __/ 
- * |_|_| |_| |_|\__,_|\__, |_|\___\__,_|_|_|  |_|_|_| |_|\___| 
- *                     __/ |                                   
- *                    |___/                                                                     
- * 
+ *  _                       _           _ __  __ _
+ * (_)                     (_)         | |  \/  (_)
+ *  _ _ __ ___   __ _  __ _ _  ___ __ _| | \  / |_ _ __   ___
+ * | | '_ ` _ \ / _` |/ _` | |/ __/ _` | | |\/| | | '_ \ / _ \
+ * | | | | | | | (_| | (_| | | (_| (_| | | |  | | | | | |  __/
+ * |_|_| |_| |_|\__,_|\__, |_|\___\__,_|_|_|  |_|_|_| |_|\___|
+ *                     __/ |
+ *                    |___/
+ *
  * This program is a third party build by ImagicalMine.
- * 
+ *
  * ImagicalMine is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -20,7 +20,7 @@
  *
  * @author ImagicalMine Team
  * @link http://forums.imagicalcorp.ml/
- * 
+ *
  *
 */
 namespace pocketmine;
@@ -236,6 +236,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	protected $foodUsageTime = 0;
 	protected $explevel = 0;
 	protected $experience = 0;
+
+	/* flag for player, to allow/disallow teleporting him or to him*/
+	protected $teleportEnabled = true;
 
 	public function getAttribute(){
 		return $this->attribute;
@@ -3392,7 +3395,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		if($this->getRealFood() - $amount < 0) $amount = $this->getRealFood();
 		$this->setFood($this->getRealFood() - $amount);
 	}
-	
+
 	public function setExperience($exp){
 		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, $exp, 0));
 		if($ev->isCancelled()) return false;
@@ -3401,7 +3404,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->updateExperience();
 		return true;
 	}
-	
+
 	public function setExpLevel($level){
 		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, 0, $level));
 		if($ev->isCancelled()) return false;
@@ -3409,18 +3412,18 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->updateExperience();
 		return true;
 	}
-	
+
 	public function getExpectedExperience(){
 		return $this->server->getExpectedExperience($this->explevel + 1);
 	}
-	
+
 	public function getLevelUpExpectedExperience(){
 		/*if($this->explevel < 16) return 2 * $this->explevel + 7;
 		elseif($this->explevel < 31) return 5 * $this->explevel - 38;
 		else return 9 * $this->explevel - 158;*/
 		return $this->getExpectedExperience() - $this->server->getExpectedExperience($this->explevel);
 	}
-	
+
 	public function calcExpLevel(){
 		while($this->experience >= $this->getExpectedExperience()){
 			$this->explevel++;
@@ -3429,7 +3432,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$this->explevel--;
 		}
 	}
-	
+
 	public function addExperience($exp){
 		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, $exp, 0, PlayerExperienceChangeEvent::ADD_EXPERIENCE));
 		if($ev->isCancelled()) return false;
@@ -3438,25 +3441,25 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->updateExperience();
 		return true;
 	}
-	
+
 	public function addExpLevel($level){
 		$this->explevel = $this->explevel + $level;
 		$this->updateExperience();
 	}
-	
+
 	public function getExperience(){
 		return $this->exp;
 	}
-	
+
 	public function getExpLevel(){
 		return $this->explevel;
 	}
-	
+
 	public function updateExperience(){
 		$this->getAttribute()->getAttribute(AttributeManager::EXPERIENCE)->setValue(($this->experience - $this->server->getExpectedExperience($this->explevel)) / ($this->getLevelUpExpectedExperience()));
 		$this->getAttribute()->getAttribute(AttributeManager::EXPERIENCE_LEVEL)->setValue($this->explevel);
 	}
-	
+
 	public function attack($damage, EntityDamageEvent $source){
 		if(!$this->isAlive()){
 			return;
@@ -3746,5 +3749,18 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$batch->encode();
 		$batch->isEncoded = true;
 		return $batch;
+	}
+
+	/**
+	 * @param bool $flag
+	 */
+	public function setTeleportEnabled($flag){
+		$this->teleportEnabled = $flag;
+	}
+	/**
+	 * @return bool
+	 */
+	public function getTeleportEnabled(){
+		return $this->teleportEnabled;
 	}
 }

--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -2,17 +2,17 @@
 
 /*
  *
- *  _                       _           _ __  __ _             
- * (_)                     (_)         | |  \/  (_)            
- *  _ _ __ ___   __ _  __ _ _  ___ __ _| | \  / |_ _ __   ___  
- * | | '_ ` _ \ / _` |/ _` | |/ __/ _` | | |\/| | | '_ \ / _ \ 
- * | | | | | | | (_| | (_| | | (_| (_| | | |  | | | | | |  __/ 
- * |_|_| |_| |_|\__,_|\__, |_|\___\__,_|_|_|  |_|_|_| |_|\___| 
- *                     __/ |                                   
- *                    |___/                                                                     
- * 
+ *  _                       _           _ __  __ _
+ * (_)                     (_)         | |  \/  (_)
+ *  _ _ __ ___   __ _  __ _ _  ___ __ _| | \  / |_ _ __   ___
+ * | | '_ ` _ \ / _` |/ _` | |/ __/ _` | | |\/| | | '_ \ / _ \
+ * | | | | | | | (_| | (_| | | (_| (_| | | |  | | | | | |  __/
+ * |_|_| |_| |_|\__,_|\__, |_|\___\__,_|_|_|  |_|_|_| |_|\___|
+ *                     __/ |
+ *                    |___/
+ *
  * This program is a third party build by ImagicalMine.
- * 
+ *
  * PocketMine is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -20,7 +20,7 @@
  *
  * @author ImagicalMine Team
  * @link http://forums.imagicalcorp.ml/
- * 
+ *
  *
 */
 
@@ -41,6 +41,7 @@ class TeleportCommand extends VanillaCommand{
 			"%pocketmine.command.tp.description",
 			"%commands.tp.usage"
 		);
+		//todo check/add permissions subcommands
 		$this->setPermission("pocketmine.command.teleport");
 	}
 
@@ -49,16 +50,71 @@ class TeleportCommand extends VanillaCommand{
 			return true;
 		}
 
-		if(count($args) < 1 or count($args) > 6){
+		$countArgs = count($args);
+
+		if($countArgs < 1 or $countArgs > 6){
 			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 
 			return true;
 		}
 
 		$target = null;
-		$origin = $sender;
 
-		if(count($args) === 1 or count($args) === 3){
+		if($countArgs === 1) {
+            //check subcommands
+		    switch($args[0]) {
+		        case 'off':
+		            //player disable teleporting to or from him
+		            return true;
+		            break;
+		        case 'on':
+		            //player enable teleporting to or from him
+		            return true;
+		            break;
+		    }
+
+		    if(false === ($sender instanceof Player)){
+		        $sender->sendMessage(TextFormat::RED . "Please provide a player!");
+
+		        return true;
+		    }
+		}
+
+		if(in_array($countArgs, array(1,3))) {
+		    //tp sender to somewhere
+		    $originName = $sender->getName();
+		    $origin = $sender;
+		}elseif(in_array($countArgs, array(2,4,5,6))) {
+		    //tp arg[0] to somewhere
+		    $originName = $args[0];
+		    $origin = $sender->getServer()->getPlayer($originName);
+		}else{
+		    //wrong
+		    return true;
+		}
+
+		if(in_array($countArgs, array(1,2))) {
+		    //tp to player
+		    $targetName = $args[$countArgs-1];
+		    $target = $sender->getServer()->getPlayer($targetName);
+		    if(!($origin instanceof Player)){
+		        $sender->sendMessage(TextFormat::RED . "Can't find player " . $originName);
+		        return true;
+		    }
+		    if(!($target instanceof Player)){
+		        $sender->sendMessage(TextFormat::RED . "Can't find player " . $targetName);
+		        return true;
+		    }
+		    $origin->teleport($target);
+		    Command::broadcastCommandMessage($sender, new TranslationContainer("commands.tp.success", array($origin->getName(), $target->getName())));
+
+		}else{
+		    //tp to position
+		}
+
+		//origin
+/*
+		if($countArgs === 1 or $countArgs === 3){
 			if($sender instanceof Player){
 				$target = $sender;
 			}else{
@@ -66,7 +122,9 @@ class TeleportCommand extends VanillaCommand{
 
 				return true;
 			}
-			if(count($args) === 1){
+
+			// check if arg is a subcommand or a player
+			if($countArgs === 1){
 				$target = $sender->getServer()->getPlayer($args[0]);
 				if($target === null){
 					$sender->sendMessage(TextFormat::RED . "Can't find player " . $args[0]);
@@ -81,7 +139,7 @@ class TeleportCommand extends VanillaCommand{
 
 				return true;
 			}
-			if(count($args) === 2){
+			if($countArgs === 2){
 				$origin = $target;
 				$target = $sender->getServer()->getPlayer($args[1]);
 				if($target === null){
@@ -92,13 +150,14 @@ class TeleportCommand extends VanillaCommand{
 			}
 		}
 
-		if(count($args) < 3){
+		if($countArgs < 3){
 			$origin->teleport($target);
 			Command::broadcastCommandMessage($sender, new TranslationContainer("commands.tp.success", [$origin->getName(), $target->getName()]));
 
 			return true;
+*/
 		}elseif($target->getLevel() !== null){
-			if(count($args) === 4 or count($args) === 6){
+			if($countArgs === 4 or $countArgs === 6){
 				$pos = 1;
 			}else{
 				$pos = 0;
@@ -110,7 +169,7 @@ class TeleportCommand extends VanillaCommand{
 			$yaw = $target->getYaw();
 			$pitch = $target->getPitch();
 
-			if(count($args) === 6 or (count($args) === 5 and $pos === 3)){
+			if($countArgs === 6 or ($countArgs === 5 and $pos === 3)){
 				$yaw = $args[$pos++];
 				$pitch = $args[$pos++];
 			}

--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -117,19 +117,19 @@ class TeleportCommand extends VanillaCommand{
                 $pos = 1;
             }
 
-            $x = $this->getRelativeDouble($target->x, $origin, $args[$pos++]);
-            $y = $this->getRelativeDouble($target->y, $origin, $args[$pos++], 0, 128);
-            $z = $this->getRelativeDouble($target->z, $origin, $args[$pos++]);
-            $yaw = $target->getYaw();
-            $pitch = $target->getPitch();
+            $x = $this->getRelativeDouble($origin->x, $origin, $args[$pos++]);
+            $y = $this->getRelativeDouble($origin->y, $origin, $args[$pos++], 0, 128);
+            $z = $this->getRelativeDouble($origin->z, $origin, $args[$pos++]);
+            $yaw = $origin->getYaw();
+            $pitch = $origin->getPitch();
 
             if($countArgs === 6 or ($countArgs === 5 and $pos === 3)){
                 $yaw = $args[$pos++];
                 $pitch = $args[$pos++];
             }
 
-            $target->teleport(new Vector3($x, $y, $z), $yaw, $pitch);
-            Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success.coordinates", array($target->getName(), round($x, 2), round($y, 2), round($z, 2))));
+            $origin->teleport(new Vector3($x, $y, $z), $yaw, $pitch);
+            Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success.coordinates", array($origin->getName(), round($x, 2), round($y, 2), round($z, 2))));
 
             return true;
         }

--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -53,7 +53,7 @@ class TeleportCommand extends VanillaCommand{
 		$countArgs = count($args);
 
 		if($countArgs < 1 or $countArgs > 6){
-			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
+			$sender->sendMessage(new TranslationContainer("commands.generic.usage", array($this->usageMessage)));
 
 			return true;
 		}
@@ -89,7 +89,7 @@ class TeleportCommand extends VanillaCommand{
 		    $originName = $args[0];
 		    $origin = $sender->getServer()->getPlayer($originName);
 		}else{
-		    //wrong
+		    $sender->sendMessage(new TranslationContainer("commands.generic.usage", array($this->usageMessage)));
 		    return true;
 		}
 
@@ -106,10 +106,32 @@ class TeleportCommand extends VanillaCommand{
 		        return true;
 		    }
 		    $origin->teleport($target);
-		    Command::broadcastCommandMessage($sender, new TranslationContainer("commands.tp.success", array($origin->getName(), $target->getName())));
+		    Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success", array($origin->getName(), $target->getName())));
 
+		    return true;
 		}else{
 		    //tp to position
+		    if($countArgs === 4 or $countArgs === 6){
+		        $pos = 1;
+		    }else{
+		        $pos = 0;
+		    }
+
+		    $x = $this->getRelativeDouble($target->x, $origin, $args[$pos++]);
+		    $y = $this->getRelativeDouble($target->y, $origin, $args[$pos++], 0, 128);
+		    $z = $this->getRelativeDouble($target->z, $origin, $args[$pos++]);
+		    $yaw = $target->getYaw();
+		    $pitch = $target->getPitch();
+
+		    if($countArgs === 6 or ($countArgs === 5 and $pos === 3)){
+		        $yaw = $args[$pos++];
+		        $pitch = $args[$pos++];
+		    }
+
+		    $target->teleport(new Vector3($x, $y, $z), $yaw, $pitch);
+		    Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success.coordinates", array($target->getName(), round($x, 2), round($y, 2), round($z, 2))));
+
+		    return true;
 		}
 
 		//origin
@@ -155,7 +177,7 @@ class TeleportCommand extends VanillaCommand{
 			Command::broadcastCommandMessage($sender, new TranslationContainer("commands.tp.success", [$origin->getName(), $target->getName()]));
 
 			return true;
-*/
+
 		}elseif($target->getLevel() !== null){
 			if($countArgs === 4 or $countArgs === 6){
 				$pos = 1;
@@ -179,9 +201,9 @@ class TeleportCommand extends VanillaCommand{
 
 			return true;
 		}
-
-		$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
+		$sender->sendMessage(new TranslationContainer("commands.generic.usage", array($this->usageMessage)));
 
 		return true;
+*/
 	}
 }

--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -35,175 +35,103 @@ use pocketmine\utils\TextFormat;
 
 class TeleportCommand extends VanillaCommand{
 
-	public function __construct($name){
-		parent::__construct(
-			$name,
-			"%pocketmine.command.tp.description",
-			"%commands.tp.usage"
-		);
-		//todo check/add permissions subcommands
-		$this->setPermission("pocketmine.command.teleport");
-	}
+    public function __construct($name){
+        parent::__construct(
+            $name,
+            "%pocketmine.command.tp.description",
+            "%commands.tp.usage"
+        );
+        //todo check/add permissions subcommands
+        $this->setPermission("pocketmine.command.teleport");
+    }
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
-		if(!$this->testPermission($sender)){
-			return true;
-		}
+    public function execute(CommandSender $sender, $currentAlias, array $args){
+        if(!$this->testPermission($sender)){
+            return true;
+        }
 
-		$countArgs = count($args);
+        $countArgs = count($args);
 
-		if($countArgs < 1 or $countArgs > 6){
-			$sender->sendMessage(new TranslationContainer("commands.generic.usage", array($this->usageMessage)));
+        if($countArgs < 1 or $countArgs > 6){
+            $sender->sendMessage(new TranslationContainer("commands.generic.usage", array($this->usageMessage)));
 
-			return true;
-		}
+            return true;
+        }
 
-		$target = null;
+        $target = null;
 
-		if($countArgs === 1) {
+        if($countArgs === 1) {
             //check subcommands
-		    switch($args[0]) {
-		        case 'off':
-		            //player disable teleporting to or from him
-		            return true;
-		            break;
-		        case 'on':
-		            //player enable teleporting to or from him
-		            return true;
-		            break;
-		    }
+            switch($args[0]) {
+                case 'off':
+                    //player disable teleporting to or from him
+                    return true;
+                    break;
+                case 'on':
+                    //player enable teleporting to or from him
+                    return true;
+                    break;
+            }
 
-		    if(false === ($sender instanceof Player)){
-		        $sender->sendMessage(TextFormat::RED . "Please provide a player!");
+            if(!($sender instanceof Player)){
+                $sender->sendMessage(TextFormat::RED . "Please provide a player!");
 
-		        return true;
-		    }
-		}
+                return true;
+            }
+        }
 
-		if(in_array($countArgs, array(1,3))) {
-		    //tp sender to somewhere
-		    $originName = $sender->getName();
-		    $origin = $sender;
-		}elseif(in_array($countArgs, array(2,4,5,6))) {
-		    //tp arg[0] to somewhere
-		    $originName = $args[0];
-		    $origin = $sender->getServer()->getPlayer($originName);
-		}else{
-		    $sender->sendMessage(new TranslationContainer("commands.generic.usage", array($this->usageMessage)));
-		    return true;
-		}
+        //set origin
+        if(in_array($countArgs, array(1,3))) {
+            //tp sender to somewhere
+            $originName = $sender->getName();
+            $origin = $sender;
+        }elseif(in_array($countArgs, array(2,4,5,6))) {
+            //tp arg[0] to somewhere
+            $originName = $args[0];
+            $origin = $sender->getServer()->getPlayer($originName);
+        }else{
+            $sender->sendMessage(new TranslationContainer("commands.generic.usage", array($this->usageMessage)));
+            return true;
+        }
 
-		if(in_array($countArgs, array(1,2))) {
-		    //tp to player
-		    $targetName = $args[$countArgs-1];
-		    $target = $sender->getServer()->getPlayer($targetName);
-		    if(!($origin instanceof Player)){
-		        $sender->sendMessage(TextFormat::RED . "Can't find player " . $originName);
-		        return true;
-		    }
-		    if(!($target instanceof Player)){
-		        $sender->sendMessage(TextFormat::RED . "Can't find player " . $targetName);
-		        return true;
-		    }
-		    $origin->teleport($target);
-		    Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success", array($origin->getName(), $target->getName())));
+        if(in_array($countArgs, array(1,2))) {
+            //tp to player
+            $targetName = $args[$countArgs-1];
+            $target = $sender->getServer()->getPlayer($targetName);
+            if(!($origin instanceof Player)){
+                $sender->sendMessage(TextFormat::RED . "Can't find player " . $originName);
+                return true;
+            }
+            if(!($target instanceof Player)){
+                $sender->sendMessage(TextFormat::RED . "Can't find player " . $targetName);
+                return true;
+            }
+            $origin->teleport($target);
+            Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success", array($origin->getName(), $target->getName())));
 
-		    return true;
-		}else{
-		    //tp to position
-		    if($countArgs === 4 or $countArgs === 6){
-		        $pos = 1;
-		    }else{
-		        $pos = 0;
-		    }
+            return true;
+        }else{
+            //tp to position
+            $pos = 0;
+            if(in_array($countArgs, array(4,6))){
+                $pos = 1;
+            }
 
-		    $x = $this->getRelativeDouble($target->x, $origin, $args[$pos++]);
-		    $y = $this->getRelativeDouble($target->y, $origin, $args[$pos++], 0, 128);
-		    $z = $this->getRelativeDouble($target->z, $origin, $args[$pos++]);
-		    $yaw = $target->getYaw();
-		    $pitch = $target->getPitch();
+            $x = $this->getRelativeDouble($target->x, $origin, $args[$pos++]);
+            $y = $this->getRelativeDouble($target->y, $origin, $args[$pos++], 0, 128);
+            $z = $this->getRelativeDouble($target->z, $origin, $args[$pos++]);
+            $yaw = $target->getYaw();
+            $pitch = $target->getPitch();
 
-		    if($countArgs === 6 or ($countArgs === 5 and $pos === 3)){
-		        $yaw = $args[$pos++];
-		        $pitch = $args[$pos++];
-		    }
+            if($countArgs === 6 or ($countArgs === 5 and $pos === 3)){
+                $yaw = $args[$pos++];
+                $pitch = $args[$pos++];
+            }
 
-		    $target->teleport(new Vector3($x, $y, $z), $yaw, $pitch);
-		    Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success.coordinates", array($target->getName(), round($x, 2), round($y, 2), round($z, 2))));
+            $target->teleport(new Vector3($x, $y, $z), $yaw, $pitch);
+            Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success.coordinates", array($target->getName(), round($x, 2), round($y, 2), round($z, 2))));
 
-		    return true;
-		}
-
-		//origin
-/*
-		if($countArgs === 1 or $countArgs === 3){
-			if($sender instanceof Player){
-				$target = $sender;
-			}else{
-				$sender->sendMessage(TextFormat::RED . "Please provide a player!");
-
-				return true;
-			}
-
-			// check if arg is a subcommand or a player
-			if($countArgs === 1){
-				$target = $sender->getServer()->getPlayer($args[0]);
-				if($target === null){
-					$sender->sendMessage(TextFormat::RED . "Can't find player " . $args[0]);
-
-					return true;
-				}
-			}
-		}else{
-			$target = $sender->getServer()->getPlayer($args[0]);
-			if($target === null){
-				$sender->sendMessage(TextFormat::RED . "Can't find player " . $args[0]);
-
-				return true;
-			}
-			if($countArgs === 2){
-				$origin = $target;
-				$target = $sender->getServer()->getPlayer($args[1]);
-				if($target === null){
-					$sender->sendMessage(TextFormat::RED . "Can't find player " . $args[1]);
-
-					return true;
-				}
-			}
-		}
-
-		if($countArgs < 3){
-			$origin->teleport($target);
-			Command::broadcastCommandMessage($sender, new TranslationContainer("commands.tp.success", [$origin->getName(), $target->getName()]));
-
-			return true;
-
-		}elseif($target->getLevel() !== null){
-			if($countArgs === 4 or $countArgs === 6){
-				$pos = 1;
-			}else{
-				$pos = 0;
-			}
-
-			$x = $this->getRelativeDouble($target->x, $sender, $args[$pos++]);
-			$y = $this->getRelativeDouble($target->y, $sender, $args[$pos++], 0, 128);
-			$z = $this->getRelativeDouble($target->z, $sender, $args[$pos++]);
-			$yaw = $target->getYaw();
-			$pitch = $target->getPitch();
-
-			if($countArgs === 6 or ($countArgs === 5 and $pos === 3)){
-				$yaw = $args[$pos++];
-				$pitch = $args[$pos++];
-			}
-
-			$target->teleport(new Vector3($x, $y, $z), $yaw, $pitch);
-			Command::broadcastCommandMessage($sender, new TranslationContainer("commands.tp.success.coordinates", [$target->getName(), round($x, 2), round($y, 2), round($z, 2)]));
-
-			return true;
-		}
-		$sender->sendMessage(new TranslationContainer("commands.generic.usage", array($this->usageMessage)));
-
-		return true;
-*/
-	}
+            return true;
+        }
+    }
 }

--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -111,7 +111,7 @@ class TeleportCommand extends VanillaCommand{
                 return true;
             }
 
-            if(($origin->getTeleportEnabled() && $target->getTeleportEnabled()) || $sender->hasPermission('pocketmine.command.teleport-always')) {
+            if(($origin->getTeleportEnabled() && $target->getTeleportEnabled()) || $sender->hasPermission('pocketmine.command.teleport.always')) {
                 $origin->teleport($target);
                 Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success", array($origin->getName(), $target->getName())));
             } else {
@@ -143,7 +143,7 @@ class TeleportCommand extends VanillaCommand{
                 $yaw = $args[$pos++];
                 $pitch = $args[$pos++];
             }
-            if($isSender || $origin->getTeleportEnabled() || $sender->hasPermission('pocketmine.command.teleport-always')) {
+            if($isSender || $origin->getTeleportEnabled() || $sender->hasPermission('pocketmine.command.teleport.always')) {
                 $origin->teleport(new Vector3($x, $y, $z), $yaw, $pitch);
                 Command::broadcastCommandMessage($origin, new TranslationContainer("commands.tp.success.coordinates", array($origin->getName(), round($x, 2), round($y, 2), round($z, 2))));
             }else{

--- a/src/pocketmine/lang/locale/deu.ini
+++ b/src/pocketmine/lang/locale/deu.ini
@@ -160,7 +160,7 @@ commands.kick.usage=/kick <Spieler> [Grund ...]
 
 commands.tp.success={%0} wurde zu {%1} teleportiert
 commands.tp.success.coordinates={%0} wurde zu {%1}, {%2}, {%3} teleportiert
-commands.tp.usage=/tp <Spieler> [Spieler 2] ODER /tp [Spieler] <x> <y> <z> [x-Rotation] [y-Rotation]
+commands.tp.usage=/tp <Spieler> [Spieler 2] ODER /tp [Spieler] <x> <y> <z> [x-Rotation] [y-Rotation]  ODER /tp off ODER /tp on
 
 commands.whitelist.list=Es gibt {%0} (von {%1}) gewhitelisteten Spielern:
 commands.whitelist.enabled=Whitelist aktiviert

--- a/src/pocketmine/lang/locale/eng.ini
+++ b/src/pocketmine/lang/locale/eng.ini
@@ -169,7 +169,7 @@ commands.kick.usage=/kick <player> [reason ...]
 
 commands.tp.success=Teleported {%0} to {%1}
 commands.tp.success.coordinates=Teleported {%0} to {%1}, {%2}, {%3}
-commands.tp.usage=/tp [target player] <destination player> OR /tp [target player] <x> <y> <z> [<y-rot> <x-rot>]
+commands.tp.usage=/tp [target player] <destination player> OR /tp [target player] <x> <y> <z> [<y-rot> <x-rot>] OR /tp off OR /tp on
 
 commands.whitelist.list=There are {%0} (out of {%1} seen) whitelisted players:
 commands.whitelist.enabled=Turned on the whitelist

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -2,17 +2,17 @@
 
 /*
  *
- *  _                       _           _ __  __ _             
- * (_)                     (_)         | |  \/  (_)            
- *  _ _ __ ___   __ _  __ _ _  ___ __ _| | \  / |_ _ __   ___  
- * | | '_ ` _ \ / _` |/ _` | |/ __/ _` | | |\/| | | '_ \ / _ \ 
- * | | | | | | | (_| | (_| | | (_| (_| | | |  | | | | | |  __/ 
- * |_|_| |_| |_|\__,_|\__, |_|\___\__,_|_|_|  |_|_|_| |_|\___| 
- *                     __/ |                                   
- *                    |___/                                                                     
- * 
+ *  _                       _           _ __  __ _
+ * (_)                     (_)         | |  \/  (_)
+ *  _ _ __ ___   __ _  __ _ _  ___ __ _| | \  / |_ _ __   ___
+ * | | '_ ` _ \ / _` |/ _` | |/ __/ _` | | |\/| | | '_ \ / _ \
+ * | | | | | | | (_| | (_| | | (_| (_| | | |  | | | | | |  __/
+ * |_|_| |_| |_|\__,_|\__, |_|\___\__,_|_|_|  |_|_|_| |_|\___|
+ *                     __/ |
+ *                    |___/
+ *
  * This program is a third party build by ImagicalMine.
- * 
+ *
  * PocketMine is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -20,7 +20,7 @@
  *
  * @author ImagicalMine Team
  * @link http://forums.imagicalcorp.ml/
- * 
+ *
  *
 */
 
@@ -117,6 +117,7 @@ abstract class DefaultPermissions{
 		self::registerPermission(new Permission(self::ROOT . ".command.enchant", "Allows the user to enchant items", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.particle", "Allows the user to create particle effects", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.teleport", "Allows the user to teleport players", Permission::DEFAULT_OP), $commands);
+		self::registerPermission(new Permission(self::ROOT . ".command.teleport.allways", "Override the player setting for teleport command", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.kick", "Allows the user to kick players", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.stop", "Allows the user to stop the server", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.list", "Allows the user to list all online players", Permission::DEFAULT_OP), $commands);

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -117,7 +117,7 @@ abstract class DefaultPermissions{
 		self::registerPermission(new Permission(self::ROOT . ".command.enchant", "Allows the user to enchant items", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.particle", "Allows the user to create particle effects", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.teleport", "Allows the user to teleport players", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.teleport.allways", "Override the player setting for teleport command", Permission::DEFAULT_OP), $commands);
+		self::registerPermission(new Permission(self::ROOT . ".command.teleport.always", "Override the player setting for teleport command", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.kick", "Allows the user to kick players", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.stop", "Allows the user to stop the server", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.list", "Allows the user to list all online players", Permission::DEFAULT_OP), $commands);


### PR DESCRIPTION
Its already explained here:
http://forums.imagicalmine.me/threads/extended-teleport-command.126/

but i will do it again:
This was a feauture request by many players on my server. They wished to be able disallow teleporting to them, or teleporting them to somewhere.
I added 2 subcommands which players can use to enable/disable the tp function
Im also added a new permission that allows admins, ops or owners to override the player setting, so they don't loose the control.
the default behavior of the teleport command is the same as before, but i have the command code rewritten to make it more readable

it runs now since 2 days on my production without any feedabck about any issue, so i would say it works.